### PR TITLE
Align routing layout with branding settings

### DIFF
--- a/resources/js/src/auth/index.ts
+++ b/resources/js/src/auth/index.ts
@@ -3,3 +3,4 @@ export * from './_models';
 export * from './AuthPage';
 export * from './RequireAuth';
 export * from './useAuthContext';
+export * from './useRoleAccess';

--- a/resources/js/src/auth/useRoleAccess.ts
+++ b/resources/js/src/auth/useRoleAccess.ts
@@ -1,0 +1,44 @@
+import { useCallback, useMemo } from 'react';
+
+import { useAuthContext } from './useAuthContext';
+
+type Role = string | { name?: string } | null | undefined;
+
+const normalizeRole = (role: Role): string | null => {
+  if (!role) {
+    return null;
+  }
+
+  if (typeof role === 'string') {
+    return role;
+  }
+
+  return role.name ?? null;
+};
+
+const useRoleAccess = () => {
+  const { currentUser } = useAuthContext();
+
+  const roles = useMemo(() => {
+    return (currentUser?.roles ?? [])
+      .map((role: Role) => normalizeRole(role))
+      .filter((role: string | null): role is string => Boolean(role));
+  }, [currentUser?.roles]);
+
+  const hasRole = useCallback(
+    (allowedRoles?: string[]) => {
+      if (!allowedRoles || allowedRoles.length === 0) {
+        return true;
+      }
+
+      return roles.some((role) => allowedRoles.includes(role));
+    },
+    [roles]
+  );
+
+  const isSuperAdmin = useCallback(() => hasRole(['super']), [hasRole]);
+
+  return { roles, hasRole, isSuperAdmin };
+};
+
+export { useRoleAccess };

--- a/resources/js/src/components/loaders/ScreenLoader.tsx
+++ b/resources/js/src/components/loaders/ScreenLoader.tsx
@@ -1,13 +1,11 @@
-import { toAbsoluteUrl } from '@/utils';
+import { useBranding } from '@/hooks';
 
 const ScreenLoader = () => {
+  const { logoSmall, logoDarkSmall } = useBranding();
   return (
     <div className="flex flex-col items-center gap-2 justify-center fixed inset-0 z-50 bg-light transition-opacity duration-700 ease-in-out">
-      <img
-        className="h-[30px] max-w-none"
-        src={toAbsoluteUrl('/media/app/mini-logo.svg')}
-        alt="logo"
-      />
+      <img className="h-[30px] max-w-none dark:hidden" src={logoSmall} alt="logo" />
+      <img className="h-[30px] max-w-none hidden dark:block" src={logoDarkSmall} alt="logo" />
       <div className="text-gray-500 font-medium text-sm">Loading...</div>
     </div>
   );

--- a/resources/js/src/components/menu/types.d.ts
+++ b/resources/js/src/components/menu/types.d.ts
@@ -182,6 +182,8 @@ export interface TBranding {
   logo_small_url?: string;
   logo_dark_url?: string;
   logo_dark_small_url?: string;
+  theme_color?: string;
+  layout?: string;
 }
 
 export interface IMenuBreadcrumb {

--- a/resources/js/src/components/menu/utils.ts
+++ b/resources/js/src/components/menu/utils.ts
@@ -1,6 +1,7 @@
 import { Children, isValidElement, ReactNode } from 'react';
 import { MenuLink } from './MenuLink';
 import { matchPath } from 'react-router';
+import { IMenuItemConfig, TMenuConfig } from './types.d';
 
 export const getMenuLinkPath = (children: ReactNode): string => {
   let path = '';
@@ -36,4 +37,70 @@ export const hasMenuActiveChild = (path: string, children: ReactNode): boolean =
   }
 
   return false;
+};
+
+const filterMenuChildrenByRoles = (
+  items: TMenuConfig | undefined,
+  hasRole: (roles?: string[]) => boolean
+): TMenuConfig => {
+  if (!items) {
+    return [];
+  }
+
+  return items
+    .map((item) => {
+      if (!hasRole(item.roles)) {
+        return null;
+      }
+
+      const filteredChildren = filterMenuChildrenByRoles(item.children, hasRole);
+
+      if (filteredChildren.length > 0) {
+        return { ...item, children: filteredChildren };
+      }
+
+      if (item.children && !item.path) {
+        return null;
+      }
+
+      if (item.children && filteredChildren.length === 0) {
+        const { children, ...rest } = item;
+        return rest;
+      }
+
+      return item;
+    })
+    .filter(Boolean) as TMenuConfig;
+};
+
+export const filterMenuConfigByRoles = (
+  items: TMenuConfig | undefined,
+  hasRole: (roles?: string[]) => boolean
+): TMenuConfig => {
+  return filterMenuChildrenByRoles(items, hasRole);
+};
+
+export const menuItemHasAccess = (
+  item: IMenuItemConfig | undefined,
+  hasRole: (roles?: string[]) => boolean
+): boolean => {
+  if (!item) {
+    return false;
+  }
+
+  if (!hasRole(item.roles)) {
+    return false;
+  }
+
+  if (!item.children || item.children.length === 0) {
+    return true;
+  }
+
+  const accessibleChildren = filterMenuChildrenByRoles(item.children, hasRole);
+
+  if (accessibleChildren.length === 0 && !item.path) {
+    return false;
+  }
+
+  return true;
 };

--- a/resources/js/src/config/settings.config.ts
+++ b/resources/js/src/config/settings.config.ts
@@ -27,7 +27,9 @@ const defaultSettings: ISettings = {
     logo_url: '',
     logo_small_url: '',
     logo_dark_url: '',
-    logo_dark_small_url: ''
+    logo_dark_small_url: '',
+    theme_color: '#00A193',
+    layout: 'demo1'
   },
   menuConfig: [
     {

--- a/resources/js/src/hooks/index.ts
+++ b/resources/js/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useResponsive';
 export * from './useScrollPosition';
 export * from './useViewport';
 export * from './useBodyClasses';
+export * from './useBranding';

--- a/resources/js/src/hooks/useBranding.ts
+++ b/resources/js/src/hooks/useBranding.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+
+import { TBranding } from '@/components/menu';
+import { useSettings } from '@/providers';
+import { toAbsoluteUrl } from '@/utils';
+
+type BrandingAssets = {
+  appName: string;
+  logo: string;
+  logoSmall: string;
+  logoDark: string;
+  logoDarkSmall: string;
+  themeColor: string;
+};
+
+const DEFAULT_LOGO = '/media/app/default-logo.svg';
+const DEFAULT_LOGO_SMALL = '/media/app/mini-logo.svg';
+const DEFAULT_THEME_COLOR = '#00A193';
+
+const resolveAsset = (path: string | undefined, fallback: string) => {
+  const assetPath = path?.trim();
+
+  if (!assetPath || assetPath.length === 0) {
+    return toAbsoluteUrl(fallback);
+  }
+
+  if (/^(?:https?:)?\/\//.test(assetPath) || assetPath.startsWith('data:')) {
+    return assetPath;
+  }
+
+  return toAbsoluteUrl(assetPath);
+};
+
+const resolveBrandingAssets = (branding?: TBranding | null): BrandingAssets => {
+  const source = branding ?? {};
+  const logo = resolveAsset(source.logo_url, DEFAULT_LOGO);
+  const logoSmall = resolveAsset(source.logo_small_url ?? source.logo_url, DEFAULT_LOGO_SMALL);
+  const logoDark = resolveAsset(source.logo_dark_url ?? source.logo_url, DEFAULT_LOGO);
+  const logoDarkSmall = resolveAsset(
+    source.logo_dark_small_url ??
+      source.logo_dark_url ??
+      source.logo_small_url ??
+      source.logo_url,
+    DEFAULT_LOGO_SMALL
+  );
+  const themeColor = source.theme_color && source.theme_color.length > 0
+    ? source.theme_color
+    : DEFAULT_THEME_COLOR;
+
+  return {
+    appName: source.app_name && source.app_name.length > 0 ? source.app_name : 'APIToolz',
+    logo,
+    logoSmall,
+    logoDark,
+    logoDarkSmall,
+    themeColor
+  };
+};
+
+const useBranding = (): BrandingAssets => {
+  const { settings } = useSettings();
+
+  return useMemo(() => resolveBrandingAssets(settings.branding), [settings.branding]);
+};
+
+export { useBranding, resolveBrandingAssets };
+export type { BrandingAssets };

--- a/resources/js/src/layouts/auth-branded/AuthBrandedLayout.tsx
+++ b/resources/js/src/layouts/auth-branded/AuthBrandedLayout.tsx
@@ -2,11 +2,13 @@ import { Link, Outlet } from 'react-router-dom';
 import { Fragment } from 'react';
 import { toAbsoluteUrl } from '@/utils';
 import useBodyClasses from '@/hooks/useBodyClasses';
+import { useBranding } from '@/hooks';
 import { AuthBrandedLayoutProvider } from './AuthBrandedLayoutProvider';
 
 const Layout = () => {
   // Applying body classes to manage the background color in dark mode
   useBodyClasses('dark:bg-coal-500');
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   return (
     <Fragment>
@@ -29,11 +31,8 @@ const Layout = () => {
         <div className="lg:rounded-xl lg:border lg:border-gray-200 lg:m-5 order-1 lg:order-2 bg-top xxl:bg-center xl:bg-cover bg-no-repeat branded-bg">
           <div className="flex flex-col p-8 lg:p-16 gap-4">
             <Link to="/">
-              <img
-                src={toAbsoluteUrl('/media/app/mini-logo.svg')}
-                className="h-[28px] max-w-none"
-                alt=""
-              />
+              <img src={logoSmall} className="h-[28px] max-w-none dark:hidden" alt="logo" />
+              <img src={logoDarkSmall} className="h-[28px] max-w-none hidden dark:block" alt="logo" />
             </Link>
 
             <div className="flex flex-col gap-3">

--- a/resources/js/src/layouts/demo1/header/Header.tsx
+++ b/resources/js/src/layouts/demo1/header/Header.tsx
@@ -4,11 +4,11 @@ import { Container } from '@/components/container';
 import { MegaMenu } from '../mega-menu';
 import { HeaderLogo, HeaderTopbar } from './';
 import { useDemo1Layout } from '../';
-import { useAuthContext } from '@/auth';
+import { useRoleAccess } from '@/auth';
 
 const Header = () => {
   const { headerSticky } = useDemo1Layout();
-  const { currentUser } = useAuthContext();
+  const { isSuperAdmin } = useRoleAccess();
 
   useEffect(() => {
     if (headerSticky) {
@@ -29,7 +29,7 @@ const Header = () => {
         <HeaderLogo />
         {/* <div></div> */}
         <div className="mt-7">
-          {currentUser?.roles?.some((role: any) => (role?.name ?? role) === 'super') ? (
+          {isSuperAdmin() ? (
             <MegaMenu />
           ) : null}
         </div>

--- a/resources/js/src/layouts/demo1/header/HeaderLogo.tsx
+++ b/resources/js/src/layouts/demo1/header/HeaderLogo.tsx
@@ -1,12 +1,10 @@
 import { Link } from 'react-router-dom';
 import { KeenIcon } from '@/components/keenicons';
-import { toAbsoluteUrl } from '@/utils';
-
 import { useDemo1Layout } from '../';
-import { useSettings } from '@/providers';
+import { useBranding } from '@/hooks';
 
 const HeaderLogo = () => {
-  const { settings } = useSettings();
+  const { logoSmall, logoDarkSmall } = useBranding();
   const { setMobileSidebarOpen, setMobileMegaMenuOpen, megaMenuEnabled } = useDemo1Layout();
 
   const handleSidebarOpen = () => {
@@ -20,11 +18,8 @@ const HeaderLogo = () => {
   return (
     <div className="flex gap-1 lg:hidden items-center -ms-1">
       <Link to="/" className="shrink-0">
-        <img
-          src={toAbsoluteUrl('/media/app/mini-logo.svg')}
-          className="max-h-[25px] w-full"
-          alt="mini-logo"
-        />
+        <img src={logoSmall} className="max-h-[25px] w-full dark:hidden" alt="mini-logo" />
+        <img src={logoDarkSmall} className="max-h-[25px] w-full hidden dark:block" alt="mini-logo" />
       </Link>
 
       <div className="flex items-center">

--- a/resources/js/src/layouts/demo1/sidebar/SidebarMenu.tsx
+++ b/resources/js/src/layouts/demo1/sidebar/SidebarMenu.tsx
@@ -17,7 +17,7 @@ import {
   MenuTitle
 } from '@/components/menu';
 import { useMenus } from '@/providers';
-import { useAuthContext } from '@/auth';
+import { useRoleAccess } from '@/auth';
 import { toLowerCase } from '@/pages/model/_helper';
 
 function toPascalCase(str: string): string {
@@ -59,9 +59,10 @@ const SidebarMenu = () => {
     'before:start-[32px]',
     'before:start-[32px]'
   ];
+  const { hasRole: canAccess } = useRoleAccess();
   const buildMenu = (items: TMenuConfig) => {
     return items
-      .filter((item) => hasRole(item.roles))
+      .filter((item) => canAccess(item.roles))
       .map((item, index) => {
         if (item.heading) {
           return buildMenuHeading(item, index);
@@ -166,7 +167,7 @@ const SidebarMenu = () => {
 
   const buildMenuItemChildren = (items: TMenuConfig, index: number, level: number = 0) => {
     return items
-      .filter((item) => hasRole(item.roles))
+      .filter((item) => canAccess(item.roles))
       .map((item, index) => {
         if (item.disabled) {
           return buildMenuItemChildDisabled(item, index, level);
@@ -303,14 +304,6 @@ const SidebarMenu = () => {
 
   const { getMenuConfig } = useMenus();
   const menuConfig = getMenuConfig('primary');
-  const { currentUser } = useAuthContext();
-
-  const hasRole = (allowedRoles?: string[]) => {
-    if (!allowedRoles || allowedRoles.length === 0) return true;
-    return currentUser?.roles?.some((role: any) => {
-      return allowedRoles.includes(role);
-    });
-  };
 
   return (
     <Menu highlight={true} multipleExpand={false} className={clsx('flex flex-col grow', itemsGap)}>

--- a/resources/js/src/layouts/demo10/Demo10LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo10/Demo10LayoutProvider.tsx
@@ -1,6 +1,5 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_SIDEBAR } from '@/config';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo10LayoutConfig } from '.';
@@ -30,6 +29,7 @@ const useDemo10Layout = () => useContext(Demo10LayoutContext);
 // Provider component that sets up the layout state and context for demo10 layout
 const Demo10LayoutProvider = ({ children }: PropsWithChildren) => {
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the demo10 layout configuration with the current layout configuration fetched via getLayout
@@ -40,7 +40,7 @@ const Demo10LayoutProvider = ({ children }: PropsWithChildren) => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // Manage state for mobile sidebar
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
 
   // When the layout state changes, set the current layout configuration in the layout provider
   useEffect(() => {

--- a/resources/js/src/layouts/demo10/header/Header.tsx
+++ b/resources/js/src/layouts/demo10/header/Header.tsx
@@ -1,11 +1,12 @@
 import { KeenIcon } from '@/components';
 import { Container } from '@/components/container';
-import { toAbsoluteUrl } from '@/utils';
 import { Link } from 'react-router-dom';
 import { useDemo10Layout } from '..';
+import { useBranding } from '@/hooks';
 
 const Header = () => {
   const { setMobileSidebarOpen } = useDemo10Layout();
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   const handleMobileSidebarOpen = () => {
     setMobileSidebarOpen(true);
@@ -15,10 +16,8 @@ const Header = () => {
     <header className="flex lg:hidden items-center fixed z-10 top-0 start-0 end-0 shrink-0 bg-[--tw-page-bg] h-[--tw-header-height]">
       <Container className="flex items-center justify-between flex-wrap gap-3">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-circle-success.svg')}
-            className="h-[34px]"
-          />
+          <img src={logoSmall} className="dark:hidden h-[34px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:inline-block h-[34px]" alt="logo" />
         </Link>
 
         <button

--- a/resources/js/src/layouts/demo2/Demo2LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo2/Demo2LayoutProvider.tsx
@@ -1,7 +1,6 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_SIDEBAR } from '@/config';
 import { useScrollPosition } from '@/hooks/useScrollPosition';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo2LayoutConfig } from './';
@@ -33,6 +32,7 @@ const useDemo2Layout = () => useContext(Demo2LayoutContext);
 // Provider component that sets up the layout state and context for Demo2 layout
 const Demo2LayoutProvider = ({ children }: PropsWithChildren) => {
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the Demo2 layout configuration with the current layout configuration fetched via getLayout
@@ -49,7 +49,7 @@ const Demo2LayoutProvider = ({ children }: PropsWithChildren) => {
   const headerSticky: boolean = scrollPosition > layout.options.header.stickyOffset;
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
 
   // When the layout state changes, set the current layout configuration in the layout provider
   useEffect(() => {

--- a/resources/js/src/layouts/demo2/header/HeaderLogo.tsx
+++ b/resources/js/src/layouts/demo2/header/HeaderLogo.tsx
@@ -1,6 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
 import { KeenIcon } from '@/components/keenicons';
-import { toAbsoluteUrl } from '@/utils';
 import {
   Menu,
   MenuArrow,
@@ -12,39 +11,55 @@ import {
   MenuToggle
 } from '@/components/menu';
 import { MENU_ROOT } from '@/config';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLanguage } from '@/i18n';
+import { useBranding } from '@/hooks';
+import { useMenus } from '@/providers';
+import { useRoleAccess } from '@/auth';
+import { menuItemHasAccess } from '@/components/menu/utils';
 
 const HeaderLogo = () => {
   const { pathname } = useLocation();
   const { isRTL } = useLanguage();
-  const [selectedMenuItem, setSelectedMenuItem] = useState(MENU_ROOT[1]);
+  const { appName, logoSmall, logoDarkSmall } = useBranding();
+  const { getMenuConfig } = useMenus();
+  const primaryMenu = getMenuConfig('primary');
+  const { hasRole } = useRoleAccess();
+
+  const accessibleRootItems = useMemo(() => {
+    return MENU_ROOT.filter((item) => {
+      if (typeof item.childrenIndex !== 'number') {
+        return true;
+      }
+
+      const menuItem = primaryMenu?.[item.childrenIndex];
+
+      return menuItemHasAccess(menuItem, hasRole);
+    });
+  }, [primaryMenu, hasRole]);
+
+  const [selectedMenuItem, setSelectedMenuItem] = useState(() => accessibleRootItems[0] ?? MENU_ROOT[0]);
 
   useEffect(() => {
-    MENU_ROOT.forEach((item) => {
-      if (item.rootPath && pathname.includes(item.rootPath)) {
-        setSelectedMenuItem(item);
-      }
-    });
-  }, [pathname]);
+    const matchedItem = accessibleRootItems.find((item) => item.rootPath && pathname.includes(item.rootPath));
+
+    if (matchedItem) {
+      setSelectedMenuItem(matchedItem);
+    } else if (!accessibleRootItems.includes(selectedMenuItem)) {
+      setSelectedMenuItem(accessibleRootItems[0] ?? selectedMenuItem);
+    }
+  }, [pathname, accessibleRootItems, selectedMenuItem]);
+
 
   return (
     <div className="flex items-center gap-2 lg:gap-5 2xl:-ml-[60px]">
       <Link to="/" className="shrink-0">
-        <img
-          src={toAbsoluteUrl('/media/app/mini-logo-circle.svg')}
-          className="dark:hidden min-h-[42px]"
-          alt="logo"
-        />
-        <img
-          src={toAbsoluteUrl('/media/app/mini-logo-circle-dark.svg')}
-          className="hidden dark:inline-block min-h-[42px]"
-          alt="logo"
-        />
+        <img src={logoSmall} className="dark:hidden min-h-[42px]" alt="logo" />
+        <img src={logoDarkSmall} className="hidden dark:inline-block min-h-[42px]" alt="logo" />
       </Link>
 
       <div className="flex items-center">
-        <h3 className="text-gray-700 text-base hidden md:block">APIToolz</h3>
+        <h3 className="text-gray-700 text-base hidden md:block">{appName}</h3>
         <span className="text-sm text-gray-400 font-medium px-2.5 hidden md:inline">/</span>
 
         <Menu className="menu-default">
@@ -70,7 +85,7 @@ const HeaderLogo = () => {
               </MenuArrow>
             </MenuToggle>
             <MenuSub className="menu-default w-48">
-              {MENU_ROOT.map((item, index) => (
+              {accessibleRootItems.map((item, index) => (
                 <MenuItem key={index} className={item === selectedMenuItem ? 'active' : ''}>
                   <MenuLink path={item.path}>
                     {item.icon && (

--- a/resources/js/src/layouts/demo2/navbar/NavbarMenu.tsx
+++ b/resources/js/src/layouts/demo2/navbar/NavbarMenu.tsx
@@ -11,12 +11,15 @@ import {
 import { useMenus } from '@/providers';
 import { useLocation } from 'react-router';
 import { useLanguage } from '@/i18n';
+import { useRoleAccess } from '@/auth';
+import { filterMenuConfigByRoles } from '@/components/menu/utils';
 
 const NavbarMenu = () => {
   const { pathname } = useLocation();
   const { getMenuConfig } = useMenus();
   const primaryMenu = getMenuConfig('primary');
   const { isRTL } = useLanguage();
+  const { hasRole } = useRoleAccess();
   let navbarMenu;
 
   if (pathname.includes('/public-profile/')) {
@@ -29,8 +32,10 @@ const NavbarMenu = () => {
     navbarMenu = primaryMenu?.[3];
   }
 
-  const buildMenu = (items: TMenuConfig) => {
-    return items.map((item, index) => {
+  const buildMenu = (items?: TMenuConfig | null) => {
+    const filteredItems = filterMenuConfigByRoles(items ?? [], hasRole);
+
+    return filteredItems.map((item, index) => {
       if (item.children) {
         return (
           <MenuItem
@@ -72,8 +77,10 @@ const NavbarMenu = () => {
     });
   };
 
-  const buildMenuChildren = (items: TMenuConfig) => {
-    return items.map((item, index) => {
+  const buildMenuChildren = (items?: TMenuConfig | null) => {
+    const filteredItems = filterMenuConfigByRoles(items ?? [], hasRole);
+
+    return filteredItems.map((item, index) => {
       if (item.children) {
         return (
           <MenuItem

--- a/resources/js/src/layouts/demo3/Demo3LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo3/Demo3LayoutProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_MODEL, MENU_SIDEBAR } from '@/config';
-import { useMenus } from '@/providers';
+import { MENU_MODEL } from '@/config';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo3LayoutConfig } from '.';
@@ -30,6 +30,7 @@ const useDemo3Layout = () => useContext(Demo3LayoutContext);
 // Provider component that sets up the layout state and context for Demo3 layout
 const Demo3LayoutProvider = ({ children }: PropsWithChildren) => {
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the Demo3 layout configuration with the current layout configuration fetched via getLayout
@@ -40,7 +41,7 @@ const Demo3LayoutProvider = ({ children }: PropsWithChildren) => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // Manage state for mobile sidebar
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
   setMenuConfig('model', MENU_MODEL);
 
   // When the layout state changes, set the current layout configuration in the layout provider

--- a/resources/js/src/layouts/demo4/Demo4LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo4/Demo4LayoutProvider.tsx
@@ -1,6 +1,5 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_SIDEBAR } from '@/config';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo4LayoutConfig } from '.';
@@ -33,6 +32,7 @@ const useDemo4Layout = () => useContext(Demo4LayoutContext);
 const Demo4LayoutProvider = ({ children }: PropsWithChildren) => {
   const { pathname } = useLocation(); // Gets the current path
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the Demo4 layout configuration with the current layout configuration fetched via getLayout
@@ -43,8 +43,8 @@ const Demo4LayoutProvider = ({ children }: PropsWithChildren) => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // Manage state for mobile sidebar
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
-  const secondaryMenu = useMenuChildren(pathname, MENU_SIDEBAR, 0); // Retrieves the secondary menu
+  setMenuConfig('primary', settings.menuConfig);
+  const secondaryMenu = useMenuChildren(pathname, settings.menuConfig, 0); // Retrieves the secondary menu
   setMenuConfig('secondary', secondaryMenu);
 
   // When the layout state changes, set the current layout configuration in the layout provider

--- a/resources/js/src/layouts/demo4/header/Header.tsx
+++ b/resources/js/src/layouts/demo4/header/Header.tsx
@@ -1,11 +1,12 @@
 import { KeenIcon } from '@/components';
 import { Container } from '@/components/container';
-import { toAbsoluteUrl } from '@/utils';
 import { Link } from 'react-router-dom';
 import { useDemo4Layout } from '../';
+import { useBranding } from '@/hooks';
 
 const Header = () => {
   const { setMobileSidebarOpen } = useDemo4Layout();
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   const handleMobileSidebarOpen = () => {
     setMobileSidebarOpen(true);
@@ -15,14 +16,8 @@ const Header = () => {
     <header className="flex lg:hidden items-center fixed z-10 top-0 start-0 end-0 shrink-0 bg-[--tw-page-bg] dark:bg-[--tw-page-bg-dark] h-[--tw-header-height]">
       <Container className="flex items-center justify-between flex-wrap gap-3">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray.svg')}
-            className="dark:hidden min-h-[30px]"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray-dark.svg')}
-            className="hidden dark:block min-h-[30px]"
-          />
+          <img src={logoSmall} className="dark:hidden min-h-[30px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:block min-h-[30px]" alt="logo" />
         </Link>
 
         <button

--- a/resources/js/src/layouts/demo4/sidebar/SidebarPrimary.tsx
+++ b/resources/js/src/layouts/demo4/sidebar/SidebarPrimary.tsx
@@ -2,7 +2,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { KeenIcon, Menu, MenuItem, MenuToggle, DefaultTooltip, MenuIcon } from '@/components';
 import { useEffect, useRef, useState } from 'react';
 import { getHeight, toAbsoluteUrl } from '@/utils';
-import { useViewport } from '@/hooks';
+import { useBranding, useViewport } from '@/hooks';
 import { DropdownUser } from '@/partials/dropdowns/user';
 import { DropdownChat } from '@/partials/dropdowns/chat';
 import { DropdownApps } from '@/partials/dropdowns/apps';
@@ -69,6 +69,7 @@ const SidebarPrimary = () => {
   }, [viewportHeight]);
 
   const { pathname } = useLocation();
+  const { logoSmall, logoDarkSmall } = useBranding();
   const [selectedMenuItem, setSelectedMenuItem] = useState(menuItems[0]);
 
   useEffect(() => {
@@ -87,14 +88,8 @@ const SidebarPrimary = () => {
     <div className="flex flex-col items-stretch shrink-0 gap-5 py-5 w-[70px] border-e border-gray-300 dark:border-gray-200">
       <div ref={headerRef} className="hidden lg:flex items-center justify-center shrink-0">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray.svg')}
-            className="dark:hidden min-h-[30px]"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray-dark.svg')}
-            className="hidden dark:block min-h-[30px]"
-          />
+          <img src={logoSmall} className="dark:hidden min-h-[30px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:block min-h-[30px]" alt="logo" />
         </Link>
       </div>
       <div className="flex grow shrink-0">

--- a/resources/js/src/layouts/demo5/Demo5LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo5/Demo5LayoutProvider.tsx
@@ -2,9 +2,8 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import { useMenuChildren } from '@/components/menu';
-import { MENU_SIDEBAR } from '@/config/menu.config';
 import { useScrollPosition } from '@/hooks/useScrollPosition';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { demo5LayoutConfig } from './Demo5LayoutConfig';
@@ -37,10 +36,11 @@ const useDemo5Layout = () => useContext(Demo5LayoutContext);
 const Demo5LayoutProvider = ({ children }: PropsWithChildren) => {
   const { pathname } = useLocation(); // Gets the current path
   const { setMenuConfig } = useMenus(); // Accesses menu configuration methods
-  const secondaryMenu = useMenuChildren(pathname, MENU_SIDEBAR, 0); // Retrieves the secondary menu
+  const { settings } = useSettings();
+  const secondaryMenu = useMenuChildren(pathname, settings.menuConfig, 0); // Retrieves the secondary menu
 
   // Sets the primary and secondary menu configurations
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
   setMenuConfig('secondary', secondaryMenu);
 
   const { getLayout, updateLayout, setCurrentLayout } = useLayout(); // Layout management methods

--- a/resources/js/src/layouts/demo5/header/HeaderLogo.tsx
+++ b/resources/js/src/layouts/demo5/header/HeaderLogo.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
-import { toAbsoluteUrl } from '@/utils';
-import { useResponsive } from '@/hooks';
+import { useResponsive, useBranding } from '@/hooks';
 import {
   Menu,
   MenuArrow,
@@ -39,6 +38,7 @@ interface IHeaderLogoStagings extends Array<IHeaderLogoStaging> {}
 const HeaderLogo = () => {
   const desktopMode = useResponsive('up', 'lg');
   const { setMobileSidebarOpen } = useDemo5Layout();
+  const { appName, logoSmall, logoDarkSmall } = useBranding();
   const { isRTL } = useLanguage();
 
   const handleSidebarOpen = () => {
@@ -47,7 +47,7 @@ const HeaderLogo = () => {
 
   const teams: IHeaderLogoTeams = [
     {
-      title: 'APIToolz',
+      title: appName,
       icon: 'profile-circle',
       urlPartial: '/public-profile/',
       path: '/public-profile/profiles/default'
@@ -101,16 +101,8 @@ const HeaderLogo = () => {
       </button>
 
       <Link to="/">
-        <img
-          src={toAbsoluteUrl('/media/app/mini-logo-circle.svg')}
-          className="dark:hidden min-h-[34px]"
-          alt="logo"
-        />
-        <img
-          src={toAbsoluteUrl('/media/app/mini-logo-circle-dark.svg')}
-          className="hidden dark:inline-block min-h-[34px]"
-          alt="logo"
-        />
+        <img src={logoSmall} className="dark:hidden min-h-[34px]" alt="logo" />
+        <img src={logoDarkSmall} className="hidden dark:inline-block min-h-[34px]" alt="logo" />
       </Link>
 
       {desktopMode && (
@@ -132,7 +124,7 @@ const HeaderLogo = () => {
               }}
             >
               <MenuToggle className="text-gray-900 text-sm font-medium">
-                APIToolz
+                {appName}
                 <MenuArrow>
                   <KeenIcon icon="down" />
                 </MenuArrow>

--- a/resources/js/src/layouts/demo6/Demo6LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo6/Demo6LayoutProvider.tsx
@@ -1,6 +1,5 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_SIDEBAR } from '@/config';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo6LayoutConfig } from '.';
@@ -30,6 +29,7 @@ const useDemo6Layout = () => useContext(Demo6LayoutContext);
 // Provider component that sets up the layout state and context for Demo6 layout
 const Demo6LayoutProvider = ({ children }: PropsWithChildren) => {
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the Demo6 layout configuration with the current layout configuration fetched via getLayout
@@ -40,7 +40,7 @@ const Demo6LayoutProvider = ({ children }: PropsWithChildren) => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // Manage state for mobile sidebar
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
 
   // When the layout state changes, set the current layout configuration in the layout provider
   useEffect(() => {

--- a/resources/js/src/layouts/demo6/header/Header.tsx
+++ b/resources/js/src/layouts/demo6/header/Header.tsx
@@ -1,11 +1,12 @@
 import { KeenIcon } from '@/components';
 import { Container } from '@/components/container';
-import { toAbsoluteUrl } from '@/utils';
 import { Link } from 'react-router-dom';
 import { useDemo6Layout } from '../';
+import { useBranding } from '@/hooks';
 
 const Header = () => {
   const { setMobileSidebarOpen } = useDemo6Layout();
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   const handleMobileSidebarOpen = () => {
     setMobileSidebarOpen(true);
@@ -15,14 +16,8 @@ const Header = () => {
     <header className="flex lg:hidden items-center fixed z-10 top-0 start-0 end-0 shrink-0 bg-[--tw-page-bg] dark:bg-[--tw-page-bg-dark] h-[--tw-header-height]">
       <Container className="flex items-center justify-between flex-wrap gap-3">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray.svg')}
-            className="dark:hidden min-h-[30px]"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray-dark.svg')}
-            className="hidden dark:block min-h-[30px]"
-          />
+          <img src={logoSmall} className="dark:hidden min-h-[30px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:block min-h-[30px]" alt="logo" />
         </Link>
 
         <button

--- a/resources/js/src/layouts/demo7/Demo7LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo7/Demo7LayoutProvider.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_SIDEBAR } from '@/config';
 import { useScrollPosition } from '@/hooks/useScrollPosition';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo7LayoutConfig } from './';
@@ -36,10 +35,11 @@ const Demo7LayoutProvider = ({ children }: PropsWithChildren) => {
   const { pathname } = useLocation(); // Gets the current path
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
   const { setMenuConfig } = useMenus(); // Accesses menu configuration methods
-  const secondaryMenu = useMenuChildren(pathname, MENU_SIDEBAR, 0); // Retrieves the secondary menu
+  const { settings } = useSettings();
+  const secondaryMenu = useMenuChildren(pathname, settings.menuConfig, 0); // Retrieves the secondary menu
 
   // Sets the primary and secondary menu configurations
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
   setMenuConfig('secondary', secondaryMenu);
 
   // Merge the Demo 9 layout configuration with the current layout configuration fetched via getLayout

--- a/resources/js/src/layouts/demo7/header/HeaderLogo.tsx
+++ b/resources/js/src/layouts/demo7/header/HeaderLogo.tsx
@@ -1,11 +1,12 @@
 import { Link } from 'react-router-dom';
 import { KeenIcon } from '@/components/keenicons';
-import { toAbsoluteUrl } from '@/utils';
 import { MegaMenu } from '../mega-menu';
 import { useDemo7Layout } from '@/layouts/demo7/Demo7LayoutProvider';
+import { useBranding } from '@/hooks';
 
 const HeaderLogo = () => {
   const { setMobileMegaMenuOpen } = useDemo7Layout();
+  const { appName, logoSmall, logoDarkSmall } = useBranding();
 
   const handleMobileMegaMenuOpen = () => {
     setMobileMegaMenuOpen(true);
@@ -15,16 +16,8 @@ const HeaderLogo = () => {
     <div className="flex items-stretch gap-10 grow">
       <div className="flex items-center gap-2.5">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-circle-primary.svg')}
-            className="dark:hidden min-h-[34px]"
-            alt="logo"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-circle-primary-dark.svg')}
-            className="hidden dark:inline-block min-h-[34px]"
-            alt="logo"
-          />
+          <img src={logoSmall} className="dark:hidden min-h-[34px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:inline-block min-h-[34px]" alt="logo" />
         </Link>
         <button
           className="lg:hidden btn btn-icon btn-light btn-clear btn-sm"
@@ -32,7 +25,7 @@ const HeaderLogo = () => {
         >
           <KeenIcon icon="burger-menu-2" />
         </button>
-        <h3 className="text-gray-900 text-lg font-medium hidden md:block">Metronic</h3>
+        <h3 className="text-gray-900 text-lg font-medium hidden md:block">{appName}</h3>
       </div>
 
       <MegaMenu />

--- a/resources/js/src/layouts/demo8/Demo8LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo8/Demo8LayoutProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { MENU_MEGA, MENU_SIDEBAR } from '@/config';
-import { useMenus } from '@/providers';
+import { MENU_MEGA } from '@/config';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { Demo8LayoutConfig } from '.';
@@ -33,6 +33,7 @@ const useDemo8Layout = () => useContext(Demo8LayoutContext);
 const Demo8LayoutProvider = ({ children }: PropsWithChildren) => {
   const { pathname } = useLocation(); // Gets the current path
   const { setMenuConfig } = useMenus(); // Hook to manage menu configurations
+  const { settings } = useSettings();
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
 
   // Merge the Demo8 layout configuration with the current layout configuration fetched via getLayout
@@ -43,9 +44,9 @@ const Demo8LayoutProvider = ({ children }: PropsWithChildren) => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false); // Manage state for mobile sidebar
 
   // Set the menu configuration for the primary menu using the provided MENU_SIDEBAR configuration
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
   setMenuConfig('mega', MENU_MEGA);
-  const secondaryMenu = useMenuChildren(pathname, MENU_SIDEBAR, 0); // Retrieves the secondary menu
+  const secondaryMenu = useMenuChildren(pathname, settings.menuConfig, 0); // Retrieves the secondary menu
   setMenuConfig('secondary', secondaryMenu);
 
   // When the layout state changes, set the current layout configuration in the layout provider

--- a/resources/js/src/layouts/demo8/header/Header.tsx
+++ b/resources/js/src/layouts/demo8/header/Header.tsx
@@ -1,11 +1,12 @@
 import { KeenIcon } from '@/components';
 import { Container } from '@/components/container';
-import { toAbsoluteUrl } from '@/utils';
 import { Link } from 'react-router-dom';
 import { useDemo8Layout } from '../';
+import { useBranding } from '@/hooks';
 
 const Header = () => {
   const { setMobileSidebarOpen } = useDemo8Layout();
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   const handleMobileSidebarOpen = () => {
     setMobileSidebarOpen(true);
@@ -15,14 +16,8 @@ const Header = () => {
     <header className="flex lg:hidden items-center fixed z-10 top-0 start-0 end-0 shrink-0 bg-[--tw-page-bg] dark:bg-[--tw-page-bg-dark] h-[--tw-header-height]">
       <Container className="flex items-center justify-between flex-wrap gap-3">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray.svg')}
-            className="dark:hidden h-[30px]"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-gray-dark.svg')}
-            className="hidden dark:inline-block h-[30px]"
-          />
+          <img src={logoSmall} className="dark:hidden h-[30px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:inline-block h-[30px]" alt="logo" />
         </Link>
 
         <button

--- a/resources/js/src/layouts/demo8/sidebar/Sidebar.tsx
+++ b/resources/js/src/layouts/demo8/sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { KeenIcon, Menu, MenuItem, MenuToggle } from '@/components';
 import { useEffect, useRef, useState } from 'react';
 import { getHeight, toAbsoluteUrl } from '@/utils';
-import { useResponsive, useViewport } from '@/hooks';
+import { useBranding, useResponsive, useViewport } from '@/hooks';
 import { DropdownUser } from '@/partials/dropdowns/user';
 import { DropdownChat } from '@/partials/dropdowns/chat';
 import { DropdownApps } from '@/partials/dropdowns/apps';
@@ -27,6 +27,7 @@ const Sidebar = () => {
   const itemChatRef = useRef<any>(null);
   const itemUserRef = useRef<any>(null);
   const { isRTL } = useLanguage();
+  const { logoSmall, logoDarkSmall } = useBranding();
 
   const handleDropdownChatShow = () => {
     window.dispatchEvent(new Event('resize'));
@@ -62,14 +63,8 @@ const Sidebar = () => {
             className="hidden lg:flex items-center justify-center shrink-0 pt-8 pb-3.5"
           >
             <Link to="/">
-              <img
-                src={toAbsoluteUrl('/media/app/mini-logo-square-gray.svg')}
-                className="dark:hidden min-h-[42px]"
-              />
-              <img
-                src={toAbsoluteUrl('/media/app/mini-logo-square-gray-dark.svg')}
-                className="hidden dark:block min-h-[42px]"
-              />
+              <img src={logoSmall} className="dark:hidden min-h-[42px]" alt="logo" />
+              <img src={logoDarkSmall} className="hidden dark:block min-h-[42px]" alt="logo" />
             </Link>
           </div>
         )}

--- a/resources/js/src/layouts/demo9/Demo9LayoutProvider.tsx
+++ b/resources/js/src/layouts/demo9/Demo9LayoutProvider.tsx
@@ -1,8 +1,7 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
-import { MENU_SIDEBAR } from '@/config';
 import { useScrollPosition } from '@/hooks/useScrollPosition';
-import { useMenus } from '@/providers';
+import { useMenus, useSettings } from '@/providers';
 import { ILayoutConfig, useLayout } from '@/providers';
 import { deepMerge } from '@/utils';
 import { useMenuChildren } from '@/components';
@@ -38,10 +37,11 @@ const Demo9LayoutProvider = ({ children }: PropsWithChildren) => {
   const { pathname } = useLocation(); // Gets the current path
   const { getLayout, setCurrentLayout } = useLayout(); // Hook to get and set layout configuration
   const { setMenuConfig } = useMenus(); // Accesses menu configuration methods
-  const secondaryMenu = useMenuChildren(pathname, MENU_SIDEBAR, 0); // Retrieves the secondary menu
+  const { settings } = useSettings();
+  const secondaryMenu = useMenuChildren(pathname, settings.menuConfig, 0); // Retrieves the secondary menu
 
   // Sets the primary and secondary menu configurations
-  setMenuConfig('primary', MENU_SIDEBAR);
+  setMenuConfig('primary', settings.menuConfig);
   setMenuConfig('secondary', secondaryMenu);
 
   // Merge the Demo9 layout configuration with the current layout configuration fetched via getLayout

--- a/resources/js/src/layouts/demo9/header/HeaderLogo.tsx
+++ b/resources/js/src/layouts/demo9/header/HeaderLogo.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-import { toAbsoluteUrl } from '@/utils';
 import {
   Menu,
   MenuArrow,
@@ -11,7 +10,7 @@ import {
   MenuToggle,
   KeenIcon
 } from '@/components';
-import { useResponsive } from '@/hooks';
+import { useResponsive, useBranding } from '@/hooks';
 
 import { useDemo9Layout } from '..';
 import { useLanguage } from '@/i18n';
@@ -33,6 +32,7 @@ const HeaderLogo = () => {
   const desktopMode = useResponsive('up', 'lg');
   const { setMobileMegaMenuOpen } = useDemo9Layout();
   const { isRTL } = useLanguage();
+  const { appName, logoSmall, logoDarkSmall } = useBranding();
 
   const handleSidebarOpen = () => {
     setMobileMegaMenuOpen(true);
@@ -40,7 +40,7 @@ const HeaderLogo = () => {
 
   const teams: IHeaderLogoTeams = [
     {
-      title: 'APIToolz',
+      title: appName,
       icon: 'profile-circle',
       urlPartial: '/public-profile/',
       path: '/public-profile/profiles/default'
@@ -71,18 +71,10 @@ const HeaderLogo = () => {
 
       <div className="flex items-center gap-2">
         <Link to="/">
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-circle.svg')}
-            className="dark:hidden min-h-[34px]"
-            alt="logo"
-          />
-          <img
-            src={toAbsoluteUrl('/media/app/mini-logo-circle-dark.svg')}
-            className="hidden dark:inline-block min-h-[34px]"
-            alt="logo"
-          />
+          <img src={logoSmall} className="dark:hidden min-h-[34px]" alt="logo" />
+          <img src={logoDarkSmall} className="hidden dark:inline-block min-h-[34px]" alt="logo" />
         </Link>
-        <h3 className="text-gray-900 text-lg font-medium hidden md:block">Metronic</h3>
+        <h3 className="text-gray-900 text-lg font-medium hidden md:block">{appName}</h3>
       </div>
 
       {desktopMode && (

--- a/resources/js/src/pages/branding/BrandingPage.tsx
+++ b/resources/js/src/pages/branding/BrandingPage.tsx
@@ -1,0 +1,409 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import clsx from 'clsx';
+import { toast } from 'sonner';
+
+import { Container } from '@/components/container';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { TBranding } from '@/components/menu';
+import { TSettingsThemeMode } from '@/config/settings.config';
+import { resolveBrandingAssets } from '@/hooks';
+import { useSettings } from '@/providers';
+
+const DEFAULT_BRANDING_COLOR = '#00A193';
+const DEFAULT_BRANDING_LAYOUT = 'demo1';
+const LAYOUT_OPTIONS = [
+  { value: 'demo1', label: 'Demo 1' },
+  { value: 'demo2', label: 'Demo 2' },
+  { value: 'demo3', label: 'Demo 3' },
+  { value: 'demo4', label: 'Demo 4' },
+  { value: 'demo5', label: 'Demo 5' },
+  { value: 'demo6', label: 'Demo 6' },
+  { value: 'demo7', label: 'Demo 7' },
+  { value: 'demo8', label: 'Demo 8' },
+  { value: 'demo9', label: 'Demo 9' },
+  { value: 'demo10', label: 'Demo 10' }
+];
+
+const mapBranding = (source?: TBranding | null): TBranding => ({
+  app_name: source?.app_name ?? '',
+  logo_url: source?.logo_url ?? '',
+  logo_small_url: source?.logo_small_url ?? '',
+  logo_dark_url: source?.logo_dark_url ?? '',
+  logo_dark_small_url: source?.logo_dark_small_url ?? '',
+  theme_color: source?.theme_color ?? DEFAULT_BRANDING_COLOR,
+  layout: source?.layout ?? DEFAULT_BRANDING_LAYOUT
+});
+
+const BrandingPage = () => {
+  const { settings, updateSettings, storeSettings, getThemeMode } = useSettings();
+
+  const settingsBranding = useMemo(() => mapBranding(settings.branding), [settings.branding]);
+  const [branding, setBranding] = useState<TBranding>(settingsBranding);
+  const [isSaving, setIsSaving] = useState(false);
+  const [themeMode, setThemeMode] = useState<TSettingsThemeMode>(settings.themeMode);
+  const [previewTheme, setPreviewTheme] = useState<'light' | 'dark'>(
+    getThemeMode() === 'dark' ? 'dark' : 'light'
+  );
+
+  useEffect(() => {
+    setBranding(settingsBranding);
+  }, [settingsBranding]);
+
+  useEffect(() => {
+    setThemeMode(settings.themeMode);
+    const resolved = getThemeMode();
+    setPreviewTheme(resolved === 'dark' ? 'dark' : 'light');
+  }, [settings.themeMode, getThemeMode]);
+
+  const handleInputChange = (key: keyof TBranding) => (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setBranding((prev) => ({
+      ...prev,
+      [key]: value
+    }));
+  };
+
+  const handleThemeColorChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setBranding((prev) => ({
+      ...prev,
+      theme_color: value
+    }));
+  };
+
+  const handleThemeSelect = (mode: TSettingsThemeMode) => {
+    setThemeMode(mode);
+    storeSettings({ themeMode: mode });
+    const resolved = mode === 'system' ? getThemeMode() : mode;
+    setPreviewTheme(resolved === 'dark' ? 'dark' : 'light');
+  };
+
+  const handleThemeToggle = (checked: boolean) => {
+    const nextMode: TSettingsThemeMode = checked ? 'dark' : 'light';
+    handleThemeSelect(nextMode);
+  };
+
+  const handleReset = () => {
+    setBranding(settingsBranding);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+    const payload = {
+      key: settings.configKey,
+      branding: {
+        ...branding,
+        theme_color: branding.theme_color && branding.theme_color.length > 0
+          ? branding.theme_color
+          : DEFAULT_BRANDING_COLOR
+      }
+    };
+
+    try {
+      const { data } = await axios.put(
+        `${import.meta.env.VITE_APP_API_URL}/appsetting/${settings.configId}`,
+        payload
+      );
+
+      const responseBranding = mapBranding(data?.branding);
+      updateSettings({ branding: responseBranding });
+      toast.success('Branding settings updated successfully.');
+    } catch (error) {
+      console.error('Failed to update branding settings', error);
+      toast.error('Unable to save branding changes. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const brandingAssets = useMemo(() => resolveBrandingAssets(branding), [branding]);
+
+  const isBrandingDirty = useMemo(() => {
+    return (
+      (branding.app_name ?? '') !== (settingsBranding.app_name ?? '') ||
+      (branding.logo_url ?? '') !== (settingsBranding.logo_url ?? '') ||
+      (branding.logo_small_url ?? '') !== (settingsBranding.logo_small_url ?? '') ||
+      (branding.logo_dark_url ?? '') !== (settingsBranding.logo_dark_url ?? '') ||
+      (branding.logo_dark_small_url ?? '') !== (settingsBranding.logo_dark_small_url ?? '') ||
+      (branding.layout ?? DEFAULT_BRANDING_LAYOUT) !==
+        (settingsBranding.layout ?? DEFAULT_BRANDING_LAYOUT) ||
+      (branding.theme_color ?? DEFAULT_BRANDING_COLOR) !==
+        (settingsBranding.theme_color ?? DEFAULT_BRANDING_COLOR)
+    );
+  }, [branding, settingsBranding]);
+
+  const appliedTheme = previewTheme === 'dark' ? 'dark' : 'light';
+  const switchChecked = themeMode === 'system' ? previewTheme === 'dark' : themeMode === 'dark';
+
+  return (
+    <form onSubmit={handleSubmit} className="h-full">
+      <Container className="py-6 space-y-8">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Branding</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Upload logo assets, choose accent colours and switch between light or dark themes.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button type="button" variant="outline" onClick={handleReset} disabled={!isBrandingDirty || isSaving}>
+              Reset
+            </Button>
+            <Button type="submit" disabled={!isBrandingDirty || isSaving}>
+              {isSaving ? 'Saving...' : 'Save changes'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Logo assets</CardTitle>
+              <CardDescription>
+                Provide the logo files that will be used across headers, sidebars and loader screens.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-2">
+                <label htmlFor="app_name" className="text-sm font-medium text-muted-foreground">
+                  Application name
+                </label>
+                <Input
+                  id="app_name"
+                  value={branding.app_name ?? ''}
+                  onChange={handleInputChange('app_name')}
+                  placeholder="APIToolz"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-muted-foreground">Default layout</label>
+                <Select
+                  value={branding.layout ?? DEFAULT_BRANDING_LAYOUT}
+                  onValueChange={(value) =>
+                    setBranding((prev) => ({
+                      ...prev,
+                      layout: value
+                    }))
+                  }
+                >
+                  <SelectTrigger className="w-full md:w-[220px]">
+                    <SelectValue placeholder="Select a layout" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LAYOUT_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Choose the layout applied across the admin pages.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-2">
+                  <label htmlFor="logo_url" className="text-sm font-medium text-muted-foreground">
+                    Primary logo URL
+                  </label>
+                  <Input
+                    id="logo_url"
+                    value={branding.logo_url ?? ''}
+                    onChange={handleInputChange('logo_url')}
+                    placeholder="/media/app/default-logo.svg"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="logo_small_url" className="text-sm font-medium text-muted-foreground">
+                    Compact logo URL
+                  </label>
+                  <Input
+                    id="logo_small_url"
+                    value={branding.logo_small_url ?? ''}
+                    onChange={handleInputChange('logo_small_url')}
+                    placeholder="/media/app/mini-logo.svg"
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-2">
+                  <label htmlFor="logo_dark_url" className="text-sm font-medium text-muted-foreground">
+                    Dark mode logo URL
+                  </label>
+                  <Input
+                    id="logo_dark_url"
+                    value={branding.logo_dark_url ?? ''}
+                    onChange={handleInputChange('logo_dark_url')}
+                    placeholder="Leave empty to reuse the primary logo"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="logo_dark_small_url" className="text-sm font-medium text-muted-foreground">
+                    Dark mode compact logo URL
+                  </label>
+                  <Input
+                    id="logo_dark_small_url"
+                    value={branding.logo_dark_small_url ?? ''}
+                    onChange={handleInputChange('logo_dark_small_url')}
+                    placeholder="Leave empty to reuse the compact logo"
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <label htmlFor="theme_color" className="text-sm font-medium text-muted-foreground">
+                  Accent colour
+                </label>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Input
+                    id="theme_color"
+                    value={branding.theme_color ?? DEFAULT_BRANDING_COLOR}
+                    onChange={handleInputChange('theme_color')}
+                    placeholder="#00A193"
+                    className="max-w-[200px]"
+                  />
+                  <input
+                    type="color"
+                    aria-label="Pick accent colour"
+                    value={branding.theme_color ?? DEFAULT_BRANDING_COLOR}
+                    onChange={handleThemeColorChange}
+                    className="h-10 w-12 cursor-pointer rounded border border-input bg-transparent p-1"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  The accent colour is displayed in previews and can be used for future theming.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Theme & preview</CardTitle>
+              <CardDescription>
+                Switch between light and dark modes and preview how your branding appears in each theme.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Theme mode</p>
+                    <p className="text-xs text-muted-foreground">
+                      Select the theme applied across the admin experience.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Switch checked={switchChecked} onCheckedChange={handleThemeToggle} />
+                    <Select
+                      value={themeMode}
+                      onValueChange={(value) => handleThemeSelect(value as TSettingsThemeMode)}
+                    >
+                      <SelectTrigger className="w-[160px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="light">Light</SelectItem>
+                        <SelectItem value="dark">Dark</SelectItem>
+                        <SelectItem value="system">System</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Preview theme</p>
+                    <p className="text-xs text-muted-foreground">
+                      Toggle to preview your logos on a {previewTheme} background.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      checked={previewTheme === 'dark'}
+                      onCheckedChange={(checked) => setPreviewTheme(checked ? 'dark' : 'light')}
+                    />
+                    <span className="text-sm font-medium capitalize">{previewTheme}</span>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter>
+              <div
+                className={clsx(
+                  'w-full rounded-lg border p-6 shadow-sm transition-colors',
+                  appliedTheme === 'dark'
+                    ? 'bg-slate-900 text-white border-slate-700'
+                    : 'bg-white text-slate-900 border-slate-200'
+                )}
+              >
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-wrap items-center gap-4">
+                    <img
+                      src={appliedTheme === 'dark' ? brandingAssets.logoDark : brandingAssets.logo}
+                      alt="Logo preview"
+                      className="h-10 w-auto"
+                    />
+                    <img
+                      src={
+                        appliedTheme === 'dark' ? brandingAssets.logoDarkSmall : brandingAssets.logoSmall
+                      }
+                      alt="Compact logo preview"
+                      className="h-8 w-auto"
+                    />
+                  </div>
+                  <div>
+                    <p className="text-lg font-semibold">{brandingAssets.appName}</p>
+                    <p className="text-sm text-muted-foreground/80">
+                      {appliedTheme === 'dark'
+                        ? 'Dark surfaces will use your dark-mode assets where available.'
+                        : 'Light surfaces will use your primary assets.'}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="text-sm font-medium">Accent colour</span>
+                    <span
+                      className="h-8 w-8 rounded-full border border-white/40"
+                      style={{ backgroundColor: brandingAssets.themeColor }}
+                    ></span>
+                    <span className="text-xs font-mono text-muted-foreground/80">
+                      {brandingAssets.themeColor}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </CardFooter>
+          </Card>
+        </div>
+      </Container>
+    </form>
+  );
+};
+
+export { BrandingPage };

--- a/resources/js/src/routing/AppRoutingSetup.tsx
+++ b/resources/js/src/routing/AppRoutingSetup.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useMemo } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 import { DefaultPage } from '@/pages/dashboards';
 
@@ -12,6 +12,7 @@ import { ModelsPage } from '@/pages/model/ModelsPage';
 import { UsersPage } from '@/pages/users/UsersPage';
 import { RolesPage } from '@/pages/roles/RolesPage';
 import { MenuConfigPage } from '@/pages/menu-config/MenuConfigPage';
+import { BrandingPage } from '@/pages/branding/BrandingPage';
 import { FormBuilderPage } from '@/pages/model/form/FormBuilderPage';
 import { SummaryWidgetPage } from '@/pages/model/summary/SummaryWidgetPage';
 import { MadePlanPage } from '@/pages/plan/MadePlanPage';
@@ -35,37 +36,77 @@ import { Demo10Layout } from '@/layouts/demo10';
 import { IntegrationsPage } from '@/pages/integrations/IntegrationPage';
 import { IntDefinitionPage } from '@/pages/integrations/IntDefinitionPage';
 import { WorkflowInstancesPage } from '@/pages/workflows/histories/WorkflowInstancesPage';
-const getLayout = (): ReactElement => {
-  const layout = localStorage.getItem('selectedLayout') || 'demo1';
+import { useSettings } from '@/providers';
 
-  switch (layout) {
-    case 'demo2':
-      return <Demo2Layout />;
-    case 'demo3':
-      return <Demo3Layout />;
-    case 'demo4':
-      return <Demo4Layout />;
-    case 'demo5':
-      return <Demo5Layout />;
-    case 'demo6':
-      return <Demo6Layout />;
-    case 'demo7':
-      return <Demo7Layout />;
-    case 'demo8':
-      return <Demo8Layout />;
-    case 'demo9':
-      return <Demo9Layout />;
-    case 'demo10':
-      return <Demo10Layout />;
-    default:
-      return <Demo1Layout />;
+const layoutRegistry = {
+  demo1: Demo1Layout,
+  demo2: Demo2Layout,
+  demo3: Demo3Layout,
+  demo4: Demo4Layout,
+  demo5: Demo5Layout,
+  demo6: Demo6Layout,
+  demo7: Demo7Layout,
+  demo8: Demo8Layout,
+  demo9: Demo9Layout,
+  demo10: Demo10Layout
+} as const;
+
+type LayoutKey = keyof typeof layoutRegistry;
+
+const DEFAULT_LAYOUT: LayoutKey = 'demo1';
+
+const normalizeLayoutKey = (value?: string | null) => value?.trim().toLowerCase() ?? '';
+
+const isLayoutKey = (value: string): value is LayoutKey =>
+  Object.prototype.hasOwnProperty.call(layoutRegistry, value);
+
+const getStoredLayout = () => {
+  if (typeof window === 'undefined') {
+    return null;
   }
+
+  return localStorage.getItem('selectedLayout');
 };
+
+const resolveLayoutKey = (preferred?: string | null): LayoutKey => {
+  const brandingLayout = normalizeLayoutKey(preferred);
+
+  if (brandingLayout && isLayoutKey(brandingLayout)) {
+    return brandingLayout;
+  }
+
+  const storedLayout = normalizeLayoutKey(getStoredLayout());
+
+  if (storedLayout && isLayoutKey(storedLayout)) {
+    return storedLayout;
+  }
+
+  return DEFAULT_LAYOUT;
+};
+
 const AppRoutingSetup = (): ReactElement => {
+  const { settings } = useSettings();
+
+  const layoutKey = useMemo(() => resolveLayoutKey(settings.branding?.layout), [settings.branding?.layout]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const stored = localStorage.getItem('selectedLayout');
+
+    if (stored !== layoutKey) {
+      localStorage.setItem('selectedLayout', layoutKey);
+    }
+  }, [layoutKey]);
+
+  const ActiveLayout = layoutRegistry[layoutKey] ?? Demo1Layout;
+
   return (
     <Routes>
       <Route element={<RequireAuth />}>
-        <Route element={getLayout()}>
+        <Route element={<ActiveLayout />}>
           <Route path="/admin" element={<DefaultPage />} />
           <Route path="/admin/plan" element={<MadePlanPage />} />
           <Route path="/admin/plan/:id" element={<MadePlanPage />} />
@@ -90,6 +131,7 @@ const AppRoutingSetup = (): ReactElement => {
           <Route path="/admin/roles" element={<RolesPage />} />
           <Route path="/admin/permission/:role" element={<PermissionsPage />} />
           <Route path="/admin/menu-config" element={<MenuConfigPage />} />
+          <Route path="/admin/branding" element={<BrandingPage />} />
         </Route>
       </Route>
       <Route path="/admin/unauthorized" element={<ErrorsRouting />} />


### PR DESCRIPTION
## Summary
- let administrators pick the default admin layout from the branding page and persist their choice
- drive the routed layout from the branding settings with a localStorage fallback for older data
- extend the branding settings schema with a stored layout key and default value

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68dbaad1ea7c832db0ae36f3316bcf04